### PR TITLE
Use rand:uniform to be OTP 20.3 compatible

### DIFF
--- a/src/erlstatsd.erl
+++ b/src/erlstatsd.erl
@@ -70,7 +70,7 @@ handle_call(_Request, _From, State) ->
 %% @private
 %%-------------------------------------------------------------------------
 handle_cast({sample, {Operation, Key, Value, SampleRate}}, State) ->
-    case random:uniform() =< SampleRate of
+    case rand:uniform() =< SampleRate of
         true ->
             handle_cast({Operation, Key, Value, SampleRate}, State);
         false ->


### PR DESCRIPTION
Starting with Erlang 20.x release the `random` module was deprecated.
This commit simply  replaces `random:uniform` with `rand:uniform` to make `erlstatsd` compatible.
Thanks